### PR TITLE
resolve undefined reference 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -470,6 +470,7 @@ libmerge_consensus_a_SOURCES = \
   consensus/params.h \
   consensus/tx_check.cpp \
   consensus/validation.h \
+  exceptions.cpp \
   hash.cpp \
   hash.h \
   prevector.h \

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/system.h>
-#include <validation.h>
+#include <uint256.h>
 
 std::vector<uint256> exceptionBlocks;
 std::vector<uint256> exceptionTransactions;


### PR DESCRIPTION
resolves 'undefined reference to isExceptionTx(uint256&)', which only occurs under win64