### PR TITLE
reset the best found proofhash per block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -47,6 +47,7 @@
 #include <util/system.h>
 #include <util/translation.h>
 #include <validationinterface.h>
+#include <wallet/stake.h>
 #include <warnings.h>
 
 #include <masternode/masternodeman.h>
@@ -2679,6 +2680,9 @@ void static UpdateTip(const CBlockIndex* pindexNew, const CChainParams& chainPar
         }
         if (nUpgraded > 0)
             AppendWarning(warningMessages, strprintf(_("%d of last 100 blocks have unexpected version").translated, nUpgraded));
+
+        //! reset the 'bestproofhash' recorder
+        stake.ResetBestStakeSeen();
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,

--- a/src/wallet/stake.cpp
+++ b/src/wallet/stake.cpp
@@ -73,15 +73,19 @@ bool CStake::MintableCoins()
     return false;
 }
 
-uint256 bestHash = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 void CStake::BestStakeSeen(uint256& hash)
 {
     if (UintToArith256(hash) < UintToArith256(bestHash)) {
         if (hash != uint256()) {
             bestHash = hash;
-            LogPrintf("best proofHash seen: %s\n", bestHash.ToString().c_str());
+            LogPrint(BCLog::POS, "best proofHash seen: %s\n", bestHash.ToString());
         }
     }
+}
+
+void CStake::ResetBestStakeSeen()
+{
+    bestHash = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 }
 
 uint256 CStake::ReturnBestStakeSeen()

--- a/src/wallet/stake.h
+++ b/src/wallet/stake.h
@@ -24,6 +24,9 @@ extern CStake stake;
  */
 class CStake
 {
+private:
+    uint256 bestHash{};
+
 public:
     unsigned int nStakeSplitThreshold = 2000;
     unsigned int nHashInterval = 22;
@@ -33,6 +36,7 @@ public:
     bool SelectStakeCoins(std::set<std::pair<const CWalletTx*, unsigned int> >& setCoins, CAmount nTargetAmount) const;
     bool CreateCoinStake(unsigned int nBits, CMutableTransaction& txNew, unsigned int& nTxNewTime);
     void BestStakeSeen(uint256& hash);
+    void ResetBestStakeSeen();
     uint256 ReturnBestStakeSeen();
 };
 


### PR DESCRIPTION
very minor feature; reset the internal 'bestproofhash' logger when chain tip changes, effectively turning it into a 'best potential proofhash' on a block by block basis.