### PR TITLE
RPC getblockstats - fee calculation incorrect

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1809,7 +1809,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             }
         }
 
-        if (tx->IsCoinBase()) {
+        if (tx->IsCoinBase() || tx->IsCoinStake()) {
             continue;
         }
 


### PR DESCRIPTION
Issue: getblockstats would create an Exception past block 57601. After farther investigation, this was caused by the POS/Masternode reward being included in the fee calculation

![merge-blockstats-exception](https://user-images.githubusercontent.com/5182697/94630657-6a7e2780-0294-11eb-9c29-920e25e8fca1.png)

Fix: ignore the Coinstake Transaction which holds the POS reward in Vout[0] and the Masternode Reward in Vout[1] this will resolves both issues



