### PR TITLE
Correct missing balance due to staked input

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -394,7 +394,7 @@
               <item>
                <widget class="QLabel" name="labelImmatureText">
                 <property name="text">
-                 <string>Immature:</string>
+                 <string>Stake:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -749,7 +749,7 @@
               <item>
                <widget class="QLabel" name="labelWatchImmatureText">
                 <property name="text">
-                 <string>Immature:</string>
+                 <string>Stake:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -38,7 +38,7 @@ public:
         Conflicted,         /**< Conflicts with other transaction or mempool **/
         Abandoned,          /**< Abandoned from the wallet **/
         /// Generated (mined) transactions
-        Immature,           /**< Mined but waiting for maturity */
+        Immature,           /**< Mined/staked but waiting for maturity */
         NotAccepted         /**< Mined but not accepted */
     };
 


### PR DESCRIPTION
This has been a longstanding bug where a previously staked input is not counted towards the wallet's current balance.