### PR TITLE
prevent walletdb from flushing wallet whilst staking

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -678,8 +678,9 @@ void ThreadStakeMinter(const CChainParams &chainparams, CConnman &connman)
     if (!gArgs.GetBoolArg("-staking", true))
         return;
     LogPrintf("ThreadStakeMinter started\n");
+    auto pwalletMain = GetMainWallet();
     try {
-        auto pwalletMain = GetMainWallet();
+        pwalletMain->setStakingFlag(true);
         BitcoinMiner(chainparams, connman, pwalletMain.get(), true);
         boost::this_thread::interruption_point();
     } catch (std::exception& e) {
@@ -687,4 +688,5 @@ void ThreadStakeMinter(const CChainParams &chainparams, CConnman &connman)
     } catch (...) {
         LogPrintf("ThreadStakeMinter() error \n");
     }
+    pwalletMain->setStakingFlag(false);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -293,6 +293,17 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(it->second);
 }
 
+bool CWallet::getStakingState()
+{
+    return this->walletStakingState;
+}
+
+void CWallet::setStakingFlag(bool status)
+{
+    this->walletStakingState = status;
+    LogPrintf("setStakingState %s\n", status ? "enabled" : "disabled");
+}
+
 void CWallet::UpgradeKeyMetadata()
 {
     if (IsLocked() || IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -673,8 +673,9 @@ class CWallet final : public WalletStorage, public interfaces::Chain::Notificati
 private:
     CKeyingMaterial vMasterKey GUARDED_BY(cs_wallet);
 
-
     bool Unlock(const CKeyingMaterial& vMasterKeyIn, bool accept_no_keys = false);
+
+    std::atomic<bool> walletStakingState{false};
 
     std::atomic<bool> fAbortRescan{false};
     std::atomic<bool> fScanningWallet{false}; // controlled by WalletRescanReserver
@@ -780,6 +781,10 @@ public:
      * This lock protects all the fields added by CWallet.
      */
     mutable RecursiveMutex cs_wallet;
+
+    //! staking state
+    bool getStakingState();
+    void setStakingFlag(bool status);
 
     /** Get database handle used by this wallet. Ideally this function would
      * not be necessary.


### PR DESCRIPTION
prevents walletdb performing a periodic flush of the wallet instance if staking is currently active